### PR TITLE
don’t notify bugsnag about 404s

### DIFF
--- a/apps/thundermoon_web/lib/thundermoon_web/bugsnag_exception_filter.ex
+++ b/apps/thundermoon_web/lib/thundermoon_web/bugsnag_exception_filter.ex
@@ -1,0 +1,9 @@
+defmodule ThundermoonWeb.BugsnagExceptionFilter do
+  def should_notify({{%{plug_status: response_status}, _}, _}, _stacktrace)
+      when is_integer(response_status) do
+    # structure used by cowboy 2.0
+    response_status < 400 or response_status >= 500
+  end
+
+  def should_notify(_e, _s), do: true
+end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -77,7 +77,9 @@ config :thundermoon, Thundermoon.Repo,
   hostname: System.get_env("DB_HOST"),
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
 
-config :bugsnag, api_key: System.get_env("BUGSNAG_API_KEY")
+config :bugsnag,
+  api_key: System.get_env("BUGSNAG_API_KEY"),
+  exception_filter: ThundermoonWeb.BugsnagExceptionFilter
 
 # Finally import the config/prod.secret.exs which loads secrets
 # and configuration from environment variables.


### PR DESCRIPTION
Don't notify bugsnag about 404 that are mainly caused by bots

https://app.bugsnag.com/m42/thundermoon/errors/5d088fa8ac03b6001a4f7e0f

use `exception_filter`
https://github.com/jarednorman/bugsnag-elixir#exception_filter