### PR TITLE
upstream to nginx

### DIFF
--- a/.semaphore/deploy.sh
+++ b/.semaphore/deploy.sh
@@ -18,6 +18,7 @@ fi
 
 echo "stack deploy"
 IMAGE=$IMAGE docker stack deploy --with-registry-auth -c docker-compose.yml --prune $APP_NAME
+docker service update --publish-add published=4000,target=4000 thundermoon_app
 
 echo " docker prune..."
 docker system prune -af

--- a/.semaphore/docker-compose.yml
+++ b/.semaphore/docker-compose.yml
@@ -6,9 +6,7 @@ services:
       DB_HOST: db
       DB_USER: postgres
       DB_PASSWORD: postgres
-      PORT: 4000
       SECRET_KEY_BASE: a_test_key_base
-      BROWSER_HOST: browser
       APP_HOST: app
     ports:
       - 4002:4002
@@ -20,9 +18,3 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
       POSTGRES_DB: thundermoon_test
-
-  browser:
-    image: wernight/phantomjs
-    ports:
-      - 8910:8910
-    command: 'phantomjs --wd'

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :thundermoon_web, ThundermoonWeb.Endpoint,
-  url: [host: "thundermoon.zero-x.net", port: 80],
+  # url: [host: "thundermoon.zero-x.net", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json",
   http: [:inet6, port: String.to_integer(System.get_env("PORT", "4000"))],
   secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :thundermoon_web, ThundermoonWeb.Endpoint,
-  # url: [host: "thundermoon.zero-x.net", port: 80],
+  url: [host: "thundermoon.zero-x.net", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json",
   http: [:inet6, port: String.to_integer(System.get_env("PORT", "4000"))],
   secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     environment:
       PORT: 4000
     ports:
-      - "80:4000"
+      - "4000:4000"
     volumes:
       - ./log:/app/log
     depends_on:
       - db
     command: sh -c './wait-for.sh db:5432 -- ./run.sh'
-      
+
   db:
     image: postgres:11.4-alpine
     env_file:


### PR DESCRIPTION
we use nginx and letsencrypt cerbot outside of docker as normal services or cronjob respectivly

docker swarm does not expose ports, therefor we do that explicitly with `docker service upgrade`

resolves #20 