### PR TITLE
Add sim as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 ENV MIX_ENV=prod
 
 COPY mix.* /app/
+COPY apps/sim/mix.exs /app/apps/sim/mix.exs
 COPY apps/thundermoon/mix.exs /app/apps/thundermoon/mix.exs
 COPY apps/thundermoon_web/mix.exs /app/apps/thundermoon_web/mix.exs
 RUN mix do deps.get --only prod, deps.compile

--- a/apps/thundermoon_web/mix.exs
+++ b/apps/thundermoon_web/mix.exs
@@ -44,6 +44,7 @@ defmodule ThundermoonWeb.MixProject do
       {:phoenix_live_view, "~> 0.2.1"},
       {:gettext, "~> 0.11"},
       {:thundermoon, in_umbrella: true},
+      {:sim, in_umbrella: true},
       {:jason, "~> 1.1"},
       {:poison, "~> 3.1"},
       {:plug_cowboy, "~> 2.0"},


### PR DESCRIPTION
fix missing sim dependency

```
[info] Application thundermoon exited: Thundermoon.Application.start(:normal, []) returned an error: shutdown: failed to start child: Thundermoon.GameOfLife
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Sim.RealmSupervisor.start_link/1 is undefined (module Sim.RealmSupervisor is not available)
            Sim.RealmSupervisor.start_link(Thundermoon.GameOfLife)
            (stdlib) supervisor.erl:379: :supervisor.do_start_child_i/3
            (stdlib) supervisor.erl:365: :supervisor.do_start_child/2
            (stdlib) supervisor.erl:349: anonymous fn/3 in :supervisor.start_children/2
            (stdlib) supervisor.erl:1157: :supervisor.children_map/4
            (stdlib) supervisor.erl:315: :supervisor.init_children/2
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
```