### PR TITLE
bump version to 0.3.1

### DIFF
--- a/apps/sim/mix.exs
+++ b/apps/sim/mix.exs
@@ -4,7 +4,7 @@ defmodule Sim.MixProject do
   def project do
     [
       app: :sim,
-      version: "0.3.0",
+      version: "0.3.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/thundermoon/mix.exs
+++ b/apps/thundermoon/mix.exs
@@ -4,7 +4,7 @@ defmodule Thundermoon.MixProject do
   def project do
     [
       app: :thundermoon,
-      version: "0.3.0",
+      version: "0.3.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/thundermoon_web/mix.exs
+++ b/apps/thundermoon_web/mix.exs
@@ -4,7 +4,7 @@ defmodule ThundermoonWeb.MixProject do
   def project do
     [
       app: :thundermoon_web,
-      version: "0.3.0",
+      version: "0.3.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,33 @@
 # Changelog
 
-## 0.4.0
+## 0.4.0 (dev)
 
 * Lotka Volterra simulation
+
+## 0.3.1
+
+* various upgrades
+
+  * Elixir 1.10.3
+
+  * Phoenix 1.5.1
+
+  * Phoenix Live View 0.13.3 (including new adaptions)
+
+  * Phoenix PubSub 2.0
+
+  * cypress 4.5.0
+
+* include Phoenix Live Dashboard (dev only)
+
+* improve pipeline by storing test containers for further steps
+
+* split Dockerfile for pipline into test and release
+
+* add credo to pipeline
+
+* remove cypress from devDependencies
+
 
 ## 0.3.0
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Thundermoon.Umbrella.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.3.0",
+      version: "0.3.1",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: [


### PR DESCRIPTION
## 0.3.1

* various upgrades

  * Elixir 1.10.3

  * Phoenix 1.5.1

  * Phoenix Live View 0.13.3 (including new adaptions)

  * Phoenix PubSub 2.0

  * cypress 4.5.0

* include Phoenix Live Dashboard (dev only)

* improve pipeline by storing test containers for further steps

* split Dockerfile for pipeline into test and release

* add credo to pipeline

* remove cypress from devDependencies